### PR TITLE
fix: remove references to build arg

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
     needs:
       - get_version
       - integrated_tests
-    uses: telicent-oss/shared-workflows/.github/workflows/vulnerability-scanning-on-repo.yml@update/for-frontend-trivy
+    uses: telicent-oss/shared-workflows/.github/workflows/vulnerability-scanning-on-repo.yml@TELFE-211/scan-secrets
     with:
       APP_NAME: access
     secrets: inherit
@@ -71,7 +71,7 @@ jobs:
     needs:
       - get_version
       - integrated_tests
-    uses: telicent-oss/shared-workflows/.github/workflows/vulnerability-scanning-on-repo.yml@update/for-frontend-trivy
+    uses: telicent-oss/shared-workflows/.github/workflows/vulnerability-scanning-on-repo.yml@TELFE-211/scan-secrets
     with:
       APP_NAME: access
       package-directory: frontend
@@ -82,7 +82,7 @@ jobs:
       - integrated_tests
       - get_version
       - vuln_scan_frontend
-    uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@update/for-frontend-trivy
+    uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@TELFE-211/scan-secrets
     with:
       APP_NAME: access
       DOCKERFILE: Dockerfile
@@ -96,7 +96,7 @@ jobs:
       - integrated_tests
       - get_version
       - vuln_scan_api
-    uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@update/for-frontend-trivy
+    uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@TELFE-211/scan-secrets
     with:
       APP_NAME: access-api
       DOCKERFILE: Dockerfile

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,7 +2,6 @@ FROM node:20-alpine as installation
 
 USER 10101
 
-ARG NPM_TOKEN
 ENV PATH /node_modules/.bin:$PATH
 WORKDIR /app
 COPY yarn.lock yarn.lock 

--- a/scripts/docker-build-ui
+++ b/scripts/docker-build-ui
@@ -12,20 +12,10 @@ trap cleanup EXIT
 # Create temp file
 echo "{}" > accessfrontend.sbom.json
 
-
-export NPM_TOKEN=$(UNMASK=true yarn --silent tefe npmrc-authtoken //npm.pkg.github.com/)
-
-if [[ -z "$NPM_TOKEN"  ]]; then
-  echo "Necessary tokens not found in .npmrc, cannot proceed with build."
-  exit 1
-fi
-
-
 # To debug it helps to use:  --no-cache \
 docker build \
     --no-cache \
     --progress=plain \
     -f ./Dockerfile \
-    --build-arg NPM_TOKEN="$NPM_TOKEN" \
     -t telicent-access-ui-local \
     --load .


### PR DESCRIPTION
Build arg is not required because all of the libraries used are OSS