### PR TITLE
fix: [TELFE-524] CVE-2023-52356

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,5 @@ dist
 # Generated in CI
 access.sbom.json
 accessfrontend.sbom.json
+
+*.gitignored*

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,7 +16,7 @@ RUN yarn build:tailwind
 RUN LOCAL_MACHINE=false yarn build 
 WORKDIR /app/build
 
-FROM nginxinc/nginx-unprivileged:stable-alpine
+FROM nginxinc/nginx-unprivileged:stable-alpine-slim
 WORKDIR /usr/share/nginx/html/access
 COPY ./accessfrontend.sbom.json /opt/telicent/sbom/sbom.json
 COPY --from=build  /app/build .

--- a/scripts/docker-build-api
+++ b/scripts/docker-build-api
@@ -1,10 +1,8 @@
 # #!/usr/bin/env bash
 set -e
-cd frontend
 
-# Function deletes tmp file
 cleanup() {
-  rm -f accessfrontend.sbom.json
+  rm -f access.sbom.json
 }
 # call the cleanup() on EXIT
 trap cleanup EXIT
@@ -12,14 +10,14 @@ trap cleanup EXIT
 [ -f image-SBOM.gitignored.json ] && rm image-SBOM.gitignored.json
 
 # Create temp file
-echo "{}" > accessfrontend.sbom.json
+echo "{}" > access.sbom.json
 
 # To debug it helps to use:  --no-cache \
 docker build \
     --no-cache \
     --progress=plain \
     -f ./Dockerfile \
-    -t telicent-access-ui-local \
+    -t telicent-access-api-local \
     --load .
 
 
@@ -29,14 +27,14 @@ trivy image  \
   --ignore-unfixed \
   --vuln-type  os,library \
   --severity HIGH,CRITICAL \
-  telicent-access-ui-local;
+  telicent-access-api-local;
 
 trivy image --format cyclonedx \
   --exit-code 0 \
   --vuln-type os,library \
   --severity HIGH,CRITICAL \
   --output image-SBOM.gitignored.json \
-  telicent-access-ui-local;
+  telicent-access-api-local;
 
 trivy sbom \
   --format table \

--- a/scripts/docker-build-ui
+++ b/scripts/docker-build-ui
@@ -22,7 +22,10 @@ docker build \
     -t telicent-access-ui-local \
     --load .
 
+echo "------- grype -------"
+syft telicent-access-ui-local -o json | grype --quiet --fail-on high;
 
+echo "------- trivy image: os,library -------"
 trivy image  \
   --format table \
   --exit-code  1 \
@@ -31,6 +34,7 @@ trivy image  \
   --severity HIGH,CRITICAL \
   telicent-access-ui-local;
 
+echo "------- trivy image --format cyclonedx: os,library -------"
 trivy image --format cyclonedx \
   --exit-code 0 \
   --vuln-type os,library \
@@ -38,6 +42,7 @@ trivy image --format cyclonedx \
   --output image-SBOM.gitignored.json \
   telicent-access-ui-local;
 
+echo "------- trivy sbom: os,library -------"
 trivy sbom \
   --format table \
   --exit-code 1 \


### PR DESCRIPTION
Work done:
```diff
-FROM nginxinc/nginx-unprivileged:stable-alpine
+FROM nginxinc/nginx-unprivileged:stable-alpine-slim
```

Fixes [nvd.nist.gov/vuln/detail/CVE-2023-52356](https://nvd.nist.gov/vuln/detail/CVE-2023-52356)


[Scan used](https://github.com/telicent-oss/telicent-access/pull/26/files#diff-4c1114efb4f33400ca685c5a8d6c00c54fe863bd972c25edd851d825c920c1adR10:~:text=scripts/docker%2Dbuild%2Dui)
<details>
  <summary>Scan result ✅</summary>

<img width="1394" alt="Screenshot 2024-08-05 at 12 14 51" src="https://github.com/user-attachments/assets/b5d7bdf0-54a1-453b-8dd2-16055241ccdc">


</details>