### PR TITLE
fix(publish.yml): TRIVY_IGNORES

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,6 +75,7 @@ jobs:
     with:
       APP_NAME: access
       package-directory: frontend
+      TRIVY_IGNORES: "./frontend/.trivyignore"
     secrets: inherit
 
   publish_frontend:


### PR DESCRIPTION
trivy can't find the trivyignore file in `./frontend`
- So I added an option to specify it 
* https://github.com/telicent-oss/shared-workflows/commit/36eea860b98052175f2592bbb4b8db72ebbe85d6

This PR uses that option