### PR TITLE
fix: add validation around group names

### DIFF
--- a/src/controllers/groups/__tests__/utils.test.js
+++ b/src/controllers/groups/__tests__/utils.test.js
@@ -35,15 +35,12 @@ describe("Groups - UTILS", () => {
 
   it("should validate group names", () => {
     // Basic valid names
-    expect(isGroupNameValid("Example_Word-123")).toBe(true);
     expect(isGroupNameValid("__valid_underscores__")).toBe(true);
     expect(isGroupNameValid("Valid---words")).toBe(true);
-    expect(isGroupNameValid("Group123")).toBe(true);
     expect(isGroupNameValid("_GroupName")).toBe(true);
     expect(isGroupNameValid("Group.Name")).toBe(true);
     expect(isGroupNameValid("Group:Name")).toBe(true);
     expect(isGroupNameValid("Group+Name")).toBe(true);
-    expect(isGroupNameValid("Group-Name.123")).toBe(true);
 
     // Single-character valid names
     expect(isGroupNameValid("A")).toBe(true);
@@ -54,7 +51,7 @@ describe("Groups - UTILS", () => {
     expect(isGroupNameValid("Group_Name-123.456:789+ABC")).toBe(true);
 
     // Complex combinations
-    expect(isGroupNameValid("__Group__Name--Test++123::456..789")).toBe(true);
+    expect(isGroupNameValid("__Group__Name--Test++123::456..ABC")).toBe(true);
     expect(isGroupNameValid("Group.Name-123:456+789_A-Z")).toBe(true);
     // Starting with invalid characters
     expect(isGroupNameValid("123InvalidStart")).toBe(false);        // Starts with digits
@@ -72,6 +69,9 @@ describe("Groups - UTILS", () => {
     expect(isGroupNameValid("Invalid@Char")).toBe(false);           // Contains at sign
 
     // Ending with invalid characters
+    expect(isGroupNameValid("Group123")).toBe(false);               // Ends with number
+    expect(isGroupNameValid("Example_Word-123")).toBe(false);       // Ends with number
+    expect(isGroupNameValid("Group-Name.123")).toBe(false);         // Ends with number
     expect(isGroupNameValid("cannot_end_with.")).toBe(false);       // Ends with dot
     expect(isGroupNameValid("cannot_end-with-")).toBe(false);       // Ends with hyphen
     expect(isGroupNameValid("cannot_end_with+")).toBe(false);       // Ends with plus

--- a/src/controllers/groups/__tests__/utils.test.js
+++ b/src/controllers/groups/__tests__/utils.test.js
@@ -36,9 +36,11 @@ describe("Groups - UTILS", () => {
   it("should validate group names", () => {
     expect(isGroupNameValid("Example_Word-123")).toBe(true);
     expect(isGroupNameValid("__valid_underscores__")).toBe(true);
+    expect(isGroupNameValid("Valid-middle+7:options.work_ok")).toBe(true);
     expect(isGroupNameValid("Valid---words")).toBe(true);
     expect(isGroupNameValid("123InvalidStart")).toBe(false);
     expect(isGroupNameValid("Invalid*Char")).toBe(false);
+    expect(isGroupNameValid("invalid?middle")).toBe(false);
     expect(isGroupNameValid("cannot_end_with.")).toBe(false);
     expect(isGroupNameValid("cannot_end-with-")).toBe(false);
     expect(isGroupNameValid("cannot_end_with+")).toBe(false);

--- a/src/controllers/groups/__tests__/utils.test.js
+++ b/src/controllers/groups/__tests__/utils.test.js
@@ -1,4 +1,4 @@
-import { isValidPayload, sendNotFound } from "../utils";
+import { isValidPayload, sendNotFound, isGroupNameValid } from "../utils";
 import TestResponse from "../../../testUtils";
 
 describe("Groups - UTILS", () => {
@@ -32,4 +32,16 @@ describe("Groups - UTILS", () => {
       message: "Group(s) not found",
     });
   });
+
+  it("should validate group names", () => {
+    expect(isGroupNameValid("Example_Word-123")).toBe(true);
+    expect(isGroupNameValid("__valid_underscores__")).toBe(true);
+    expect(isGroupNameValid("Valid---words")).toBe(true);
+    expect(isGroupNameValid("123InvalidStart")).toBe(false);
+    expect(isGroupNameValid("Invalid*Char")).toBe(false);
+    expect(isGroupNameValid("cannot_end_with.")).toBe(false);
+    expect(isGroupNameValid("cannot_end-with-")).toBe(false);
+    expect(isGroupNameValid("cannot_end_with+")).toBe(false);
+    expect(isGroupNameValid("cannot_end_with:")).toBe(false);
+  })
 });

--- a/src/controllers/groups/__tests__/utils.test.js
+++ b/src/controllers/groups/__tests__/utils.test.js
@@ -34,16 +34,101 @@ describe("Groups - UTILS", () => {
   });
 
   it("should validate group names", () => {
+    // Basic valid names
     expect(isGroupNameValid("Example_Word-123")).toBe(true);
     expect(isGroupNameValid("__valid_underscores__")).toBe(true);
-    expect(isGroupNameValid("Valid-middle+7:options.work_ok")).toBe(true);
     expect(isGroupNameValid("Valid---words")).toBe(true);
-    expect(isGroupNameValid("123InvalidStart")).toBe(false);
-    expect(isGroupNameValid("Invalid*Char")).toBe(false);
-    expect(isGroupNameValid("invalid?middle")).toBe(false);
-    expect(isGroupNameValid("cannot_end_with.")).toBe(false);
-    expect(isGroupNameValid("cannot_end-with-")).toBe(false);
-    expect(isGroupNameValid("cannot_end_with+")).toBe(false);
-    expect(isGroupNameValid("cannot_end_with:")).toBe(false);
+    expect(isGroupNameValid("Group123")).toBe(true);
+    expect(isGroupNameValid("_GroupName")).toBe(true);
+    expect(isGroupNameValid("Group.Name")).toBe(true);
+    expect(isGroupNameValid("Group:Name")).toBe(true);
+    expect(isGroupNameValid("Group+Name")).toBe(true);
+    expect(isGroupNameValid("Group-Name.123")).toBe(true);
+
+    // Single-character valid names
+    expect(isGroupNameValid("A")).toBe(true);
+    expect(isGroupNameValid("a")).toBe(true);
+    expect(isGroupNameValid("_")).toBe(true);
+
+    // Mixed allowed characters
+    expect(isGroupNameValid("Group_Name-123.456:789+ABC")).toBe(true);
+
+    // Complex combinations
+    expect(isGroupNameValid("__Group__Name--Test++123::456..789")).toBe(true);
+    expect(isGroupNameValid("Group.Name-123:456+789_A-Z")).toBe(true);
+    // Starting with invalid characters
+    expect(isGroupNameValid("123InvalidStart")).toBe(false);        // Starts with digits
+    expect(isGroupNameValid("-InvalidStart")).toBe(false);          // Starts with hyphen
+    expect(isGroupNameValid(".InvalidStart")).toBe(false);          // Starts with dot
+    expect(isGroupNameValid(":InvalidStart")).toBe(false);          // Starts with colon
+    expect(isGroupNameValid("+InvalidStart")).toBe(false);          // Starts with plus
+    expect(isGroupNameValid("*InvalidStart")).toBe(false);          // Starts with asterisk
+
+    // Containing invalid characters in the middle
+    expect(isGroupNameValid("Invalid*Char")).toBe(false);           // Contains asterisk
+    expect(isGroupNameValid("Invalid Char")).toBe(false);           // Contains space
+    expect(isGroupNameValid("Invalid/Char")).toBe(false);           // Contains slash
+    expect(isGroupNameValid("Invalid#Char")).toBe(false);           // Contains hash
+    expect(isGroupNameValid("Invalid@Char")).toBe(false);           // Contains at sign
+
+    // Ending with invalid characters
+    expect(isGroupNameValid("cannot_end_with.")).toBe(false);       // Ends with dot
+    expect(isGroupNameValid("cannot_end-with-")).toBe(false);       // Ends with hyphen
+    expect(isGroupNameValid("cannot_end_with+")).toBe(false);       // Ends with plus
+    expect(isGroupNameValid("cannot_end_with:")).toBe(false);       // Ends with colon
+    expect(isGroupNameValid("cannot_end_with*")).toBe(false);       // Ends with asterisk
+
+    // Empty string
+    expect(isGroupNameValid("")).toBe(false);
+
+    // Strings with only invalid characters
+    expect(isGroupNameValid(".")).toBe(false);
+    expect(isGroupNameValid("-")).toBe(false);
+    expect(isGroupNameValid(":")).toBe(false);
+    expect(isGroupNameValid("+")).toBe(false);
+    expect(isGroupNameValid("*")).toBe(false);
+
+    // Strings with mixed invalid start and end
+    expect(isGroupNameValid("123InvalidEnd-")).toBe(false);
+    expect(isGroupNameValid("*InvalidEnd.")).toBe(false);
+    expect(isGroupNameValid(":InvalidEnd+")).toBe(false);
+
+    // Strings with dubious looking but valid sequences
+    expect(isGroupNameValid("valid..Name")).toBe(true);          // Double dots 
+    expect(isGroupNameValid("valid--Name")).toBe(true);          // Double hyphens
+    expect(isGroupNameValid("valid::Name")).toBe(true);          // Double colons
+    expect(isGroupNameValid("valid++Name")).toBe(true);          // Double pluses
+
+    // Strings with trailing invalid characters
+    expect(isGroupNameValid("ValidName.")).toBe(false);
+    expect(isGroupNameValid("ValidName-")).toBe(false);
+    expect(isGroupNameValid("ValidName:")).toBe(false);
+    expect(isGroupNameValid("ValidName+")).toBe(false);
+
+    // Strings with leading and trailing invalid characters
+    expect(isGroupNameValid("-Invalid-")).toBe(false);
+    expect(isGroupNameValid(".Invalid.")).toBe(false);
+    expect(isGroupNameValid(":Invalid:")).toBe(false);
+    expect(isGroupNameValid("+Invalid+")).toBe(false);
+    // Single-character invalid names
+    expect(isGroupNameValid("1")).toBe(false);                       // Starts with digit
+    expect(isGroupNameValid("-")).toBe(false);                       // Single hyphen
+    expect(isGroupNameValid(".")).toBe(false);                       // Single dot
+    expect(isGroupNameValid(":")).toBe(false);                       // Single colon
+    expect(isGroupNameValid("+")).toBe(false);                       // Single plus
+    expect(isGroupNameValid("*")).toBe(false);
+
+    // Extremely long strings (assuming no maximum length, but good to test)
+    expect(isGroupNameValid("GroupName".repeat(1000))).toBe(true);  // 9000 characters long
+
+    // Unicode characters (if not allowed)
+    expect(isGroupNameValid("GrüßGroupe")).toBe(false);              // Contains 'ü' and 'ß'
+    expect(isGroupNameValid("グループ名")).toBe(false);               // Japanese characters
+    expect(isGroupNameValid("Группа")).toBe(false);                  // Cyrillic characters
+    expect(isGroupNameValid("Group😊Name")).toBe(false);             // Emoji
+
+    // Null or undefined inputs (if applicable)
+    expect(isGroupNameValid(null)).toBe(false);
+    expect(isGroupNameValid(undefined)).toBe(false);
   })
 });

--- a/src/controllers/groups/create.js
+++ b/src/controllers/groups/create.js
@@ -33,7 +33,7 @@ export const createGroup = async (req, res) => {
     return sendErrorResponse(res, {
       code: 400,
       message: "The group name contains invalid characters.",
-      detail: "https://github.com/telicent-oss/rdf-abac/blob/main/docs/abac-specification.md#syntax-of-words Name must start and end with letters or an underscore. Can contain alphanumeric characters plus : – _ +",
+      detail: "https://github.com/telicent-oss/rdf-abac/blob/main/docs/abac-specification.md#syntax-of-words",
     });
   }
   const payload = {

--- a/src/controllers/groups/create.js
+++ b/src/controllers/groups/create.js
@@ -1,5 +1,5 @@
 import groupsModel from "../../database/models/Groups";
-import { isValidPayload } from "./utils";
+import { isGroupNameValid, isValidPayload } from "./utils";
 import {
   isBodyEmpty,
   sendErrorResponse,
@@ -22,13 +22,20 @@ export const createGroup = async (req, res) => {
   if (!label || !description) {
     return sendErrorResponse(res, {
       code: 400,
-      message: `Fields missing: ${!label ? "Name, " : ""}${
-        !description ? "Description" : ""
-      }`.replace(/,\s*$/, ""),
+      message: `Fields missing: ${!label ? "Name, " : ""}${!description ? "Description" : ""
+        }`.replace(/,\s*$/, ""),
     });
   }
 
   const id = `urn:${organisation}:groups:${label}`;
+  if (!isGroupNameValid(id)) {
+
+    return sendErrorResponse(res, {
+      code: 400,
+      message: "The group name contains invalid characters.",
+      detail: "Name must start and end with letters or an underscore. Can contain alphanumeric characters plus : – _ +",
+    });
+  }
   const payload = {
     group_id: id,
     label,
@@ -54,9 +61,8 @@ export const createGroup = async (req, res) => {
     const { code } = error;
     if (code === 11000) {
       error.code = 409;
-      error.message = `Group with ${
-        Object.keys(error.keyPattern)[0]
-      }, ${label}, already exists`;
+      error.message = `Group with ${Object.keys(error.keyPattern)[0]
+        }, ${label}, already exists`;
     }
     sendErrorResponse(res, error);
   }

--- a/src/controllers/groups/create.js
+++ b/src/controllers/groups/create.js
@@ -33,7 +33,7 @@ export const createGroup = async (req, res) => {
     return sendErrorResponse(res, {
       code: 400,
       message: "The group name contains invalid characters.",
-      detail: "https://github.com/telicent-oss/rdf-abac/blob/main/docs/abac-specification.md: Name must start and end with letters or an underscore. Can contain alphanumeric characters plus : – _ +",
+      detail: "https://github.com/telicent-oss/rdf-abac/blob/main/docs/abac-specification.md#syntax-of-words Name must start and end with letters or an underscore. Can contain alphanumeric characters plus : – _ +",
     });
   }
   const payload = {

--- a/src/controllers/groups/create.js
+++ b/src/controllers/groups/create.js
@@ -33,7 +33,7 @@ export const createGroup = async (req, res) => {
     return sendErrorResponse(res, {
       code: 400,
       message: "The group name contains invalid characters.",
-      detail: "Name must start and end with letters or an underscore. Can contain alphanumeric characters plus : – _ +",
+      detail: "https://github.com/telicent-oss/rdf-abac/blob/main/docs/abac-specification.md: Name must start and end with letters or an underscore. Can contain alphanumeric characters plus : – _ +",
     });
   }
   const payload = {

--- a/src/controllers/groups/utils.js
+++ b/src/controllers/groups/utils.js
@@ -11,13 +11,13 @@ export const isGroupNameValid = (input) => {
   if (Boolean(input) === false) return false;
   const regex = new RegExp(
     "^" + // ^ - Starts with...
-      "[A-Za-z_]" + // letter char (uppercase or lowercase) or an underscore
-      "(" + // ( - START optional capture groupe
-      "[A-Za-z0-9_\\.\\-:+]*" + // Zero or more letters, digits, _, ., -, : or +
-      "[A-Za-z0-9_]" + // IF additional characters
-      // THEN last char must be a letter, digit, or underscore
-      ")?" + // )? - END optional capturing group
-      "$"
+    "[A-Za-z_]" + // letter char (uppercase or lowercase) or an underscore
+    "(" + // ( - START optional capture groupe
+    "[A-Za-z0-9_\\.\\-:+]*" + // Zero or more letters, digits, _, ., -, : or +
+    "[A-Za-z_]" + // IF additional characters
+    // THEN last char must be a letter, digit, or underscore
+    ")?" + // )? - END optional capturing group
+    "$"
   );
   return regex.test(input)
 }

--- a/src/controllers/groups/utils.js
+++ b/src/controllers/groups/utils.js
@@ -7,6 +7,8 @@ export const sendNotFound = (res) =>
   res.status(404).send(buildErrorObject(404, "Group(s) not found"));
 
 export const isGroupNameValid = (input) => {
+  // Check to see if string is null or undefined
+  if (Boolean(input) === false) return false;
   const regex = new RegExp(/^[A-Za-z_]([A-Za-z0-9_\.\-:+]*[A-Za-z0-9_])?$/);
   return regex.test(input)
 }

--- a/src/controllers/groups/utils.js
+++ b/src/controllers/groups/utils.js
@@ -5,3 +5,8 @@ export const isValidPayload = ({ label, description } = {}) =>
 
 export const sendNotFound = (res) =>
   res.status(404).send(buildErrorObject(404, "Group(s) not found"));
+
+export const isGroupNameValid = (input) => {
+  const regex = new RegExp(/^[A-Za-z_]([A-Za-z0-9_\.\-:+]*[A-Za-z0-9_])?$/);
+  return regex.test(input)
+}

--- a/src/controllers/groups/utils.js
+++ b/src/controllers/groups/utils.js
@@ -9,6 +9,15 @@ export const sendNotFound = (res) =>
 export const isGroupNameValid = (input) => {
   // Check to see if string is null or undefined
   if (Boolean(input) === false) return false;
-  const regex = new RegExp(/^[A-Za-z_]([A-Za-z0-9_\.\-:+]*[A-Za-z0-9_])?$/);
+  const regex = new RegExp(
+    "^" + // ^ - Starts with...
+      "[A-Za-z_]" + // letter char (uppercase or lowercase) or an underscore
+      "(" + // ( - START optional capture groupe
+      "[A-Za-z0-9_\\.\\-:+]*" + // Zero or more letters, digits, _, ., -, : or +
+      "[A-Za-z0-9_]" + // IF additional characters
+      // THEN last char must be a letter, digit, or underscore
+      ")?" + // )? - END optional capturing group
+      "$"
+  );
   return regex.test(input)
 }


### PR DESCRIPTION
https://telicent.atlassian.net/browse/TELFE-637

Add validation checks to group names based off of the [spec](https://github.com/telicent-oss/rdf-abac/blob/8b7cd6e789ebaff028b7c5c366c8c7669a891c47/docs/abac-specification.md)

Unit tests added to utils

```javascript
it("should validate group names", () => {
    expect(isGroupNameValid("Example_Word-123")).toBe(true);
    expect(isGroupNameValid("__valid_underscores__")).toBe(true);
    expect(isGroupNameValid("Valid---words")).toBe(true);
    expect(isGroupNameValid("123InvalidStart")).toBe(false);
    expect(isGroupNameValid("Invalid*Char")).toBe(false);
    expect(isGroupNameValid("cannot_end_with.")).toBe(false);
    expect(isGroupNameValid("cannot_end-with-")).toBe(false);
    expect(isGroupNameValid("cannot_end_with+")).toBe(false);
    expect(isGroupNameValid("cannot_end_with:")).toBe(false);
})
```

When user tries to create a group with an invalid name a `400` response will be returned.