### PR TITLE
fix(errors): db codes used as http codes

### DIFF
--- a/src/controllers/utils.js
+++ b/src/controllers/utils.js
@@ -1,4 +1,5 @@
 import { SUCCESS_CODE, INVALID_CODE } from "./constants";
+import logger from '../lib/logger';
 
 export const buildErrorObject = (code, message, detail) => ({
   code,
@@ -23,8 +24,16 @@ export const sendInvalidRequest = (res) =>
     .status(INVALID_CODE)
     .send(buildErrorObject(INVALID_CODE, "Invalid request"));
 
-export const sendErrorResponse = (res, { code, message, detail }) =>
-  res.status(code).send(buildErrorObject(code, message, detail));
+
+export const sendErrorResponse = (res, { code, message, detail }) => {
+  const httpCode = Math.max(400, Math.min(599, code));
+  if (httpCode !== code) {
+    console.warn(
+      `Expected HTTP error code, got ${code} (transformed to ${httpCode})`
+    );
+  }
+  res.status(httpCode).send(buildErrorObject(code, message, detail));
+};
 
 export const setupSuccessResponseCode =
   (code) =>

--- a/src/controllers/utils.js
+++ b/src/controllers/utils.js
@@ -32,7 +32,7 @@ export const sendErrorResponse = (res, { code, message, detail }) => {
       `Expected HTTP error code, got ${code} (transformed to ${httpCode})`
     );
   }
-  res.status(httpCode).send(buildErrorObject(code, message, detail));
+  return res.status(httpCode).send(buildErrorObject(code, message, detail));
 };
 
 export const setupSuccessResponseCode =

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -9,6 +9,9 @@ const logger = {
   info: (msg) => {
     console.log(`%c INFO: ${msg}`, "color: green");
   },
+  warn: (msg) => {
+    console.warn(`%c WARN: ${msg}`, "color: yellow");
+  },
   error: (msg) => {
     console.log(`%c ERROR: ${msg}`, "color: red");
   },


### PR DESCRIPTION
I tried to do a more thorough fix, but thought better of it.

- this is just some defensive code biasing for a minimal blast-radius



<details>
  <summary>On abandoned approach</summary>
  
Better solution would be to map db error codes to http error codes, and hide any potentially sensitive error strings.

But I couldn't be sure (without extensive some testing) that I could make the determination between an database error with mongo error codes - and an error with http codes. Mongose seems to raise both.

And its not something we can afford to mess up.

Abandoned WIP code:
```diff
diff --git a/src/controllers/groups/read.js b/src/controllers/groups/read.js
index 5e64397..5770906 100644
--- a/src/controllers/groups/read.js
+++ b/src/controllers/groups/read.js
@@ -1,5 +1,6 @@
 import groupsModel from "../../database/models/Groups";
 import { sendNotFound } from "./utils";
+
 import { sendErrorResponse, sendResults } from "../utils";
 import { Types } from "mongoose";

@@ -23,10 +24,6 @@ export const getAllGroups = async (label) => {

     return { data: groups };
   } catch (error) {
-    const { code } = error;
-    if (!code || code > 500) {
-      error.code = 500;
-    }
     return { error };
   }
 };
@@ -73,10 +70,6 @@ export const getGroup = async (req, res) => {

     sendResults(res, groups[0]);
   } catch (error) {
-    const { code } = error;
-    if (!code || code > 500) {
-      error.code = 500;
-    }
     sendErrorResponse(res, error);
   }
 };
diff --git a/src/controllers/utils.js b/src/controllers/utils.js
index ce4e3b8..3493d06 100644
--- a/src/controllers/utils.js
+++ b/src/controllers/utils.js
@@ -1,3 +1,4 @@
+import { MongooseError, Mongoose } from "mongoose";
 import { SUCCESS_CODE, INVALID_CODE } from "./constants";
 import logger from '../lib/logger';

@@ -25,6 +26,50 @@ export const sendInvalidRequest = (res) =>
     .send(buildErrorObject(INVALID_CODE, "Invalid request"));


+export const convertErrorCodeFromMongoToHTTP = (dbErrorCode) => {
+  if (typeof dbErrorCode !== "number") {
+    logger.warn(
+      `Expected MongoDB error code number, got ${dbErrorCode} (${typeof dbErrorCode})`
+    );
+    return undefined;
+  }
+  // https://www.mongodb.com/docs/manual/reference/error-codes/
+  switch (dbErrorCode) {
+    // If confident, map certain MongoDB errors to HTTP status dbErrorCodes
+    case 11000: // Duplicate Key
+      return 409; // Conflict
+    // If not confident, map all other MongoDB errors to 500
+    case 13: // return 401; // Unauthorized
+    case 18: // return 401; // Authentication Failed
+    case 20: // return 409; // Write Conflict / Conflict
+    case 112: // return 409; // Write Conflict (Legacy) / Conflict
+    case 50: // return 504; // MaxTimeMSExpired / Gateway Timeout
+    default:
+      return 500; // Catch-all, including non-db error codes
+  }
+};
+
+const isMongoError = (error) => {
+  return (
+    error instanceof MongooseError || // Checks for Mongoose-specific errors
+    error.name === 'MongoError' ||
+    error.name === 'MongoServerError'
+  );
+}
+
+export const dbErrorToHttpPayload = (error) => {
+  if (!isMongoError(error)) {
+    return error;
+  }
+  const { code, name } = error;
+
+  return {
+    detail: `An unexpected error occurred`,
+    message: `The server encountered a problem processing the request: ${name} code ${code}`,
+    code: convertErrorCodeFromMongoToHTTP(code),
+  };
+};
+
 export const sendErrorResponse = (res, { code, message, detail }) => {
   const httpCode = Math.max(400, Math.min(599, code));
   if (httpCode !== code) {
```

```js
import { convertErrorCodeFromMongoToHTTP, dbErrorToHttpPayload } from "./utils";
import { EOL } from "os";
test("convertErrorCodeFromMongoToHTTP", () => {
  expect(
    [
      9,
      13, // Unauthorized
      18, // Authentication Failed
      20, // Write Conflict / Conflict
      50, // MaxTimeMSExpired / Gateway Timeout
      11000, // Duplicate Key
      112, // Write Conflict (Legacy) / Conflict
      "9",
    ]
      .map(
        (el) =>
          `${
            typeof el === "string" ? `"${el}"` : el
          } = ${convertErrorCodeFromMongoToHTTP(el)}`
      )
      .join(EOL)
  ).toMatchInlineSnapshot(`
"9 = 500
13 = 500
18 = 500
20 = 500
50 = 500
11000 = 409
112 = 500
"9" = undefined"
`);
});

test("dbErrorToHttpPayload", () => {
  expect(
  dbErrorToHttpPayload({
    code: 9,
    message: "potentially sensitive description of what went wrong",
    name: "MongoError"
  })
).toMatchInlineSnapshot(`
{
  "code": 500,
  "detail": "An unexpected error occurred",
  "message": "The server encountered a problem processing the request: MongoError code 9",
}
`);
});

```

</details>

# Testing

Just ran the test suite - passed
