### PR TITLE
fix(groups): [TELFE-701] remove pipeline operator

### DIFF
--- a/src/controllers/groups/read.js
+++ b/src/controllers/groups/read.js
@@ -51,19 +51,25 @@ export const getGroup = async (req, res) => {
           from: "users",
           localField: "group_id",
           foreignField: "userGroups",
-          pipeline: [
+          as: "users",
+        },
+      },
             {
-              $project: {
-                id: 1,
-                name: 1,
-                email: 1,
-                active: 1,
-                labels: 1,
-                userGroups: 1,
+        $addFields: {
+          users: {
+            $map: {
+              input: "$users",
+              as: "user",
+              in: {
+                id: "$$user.id",
+                name: "$$user.name",
+                email: "$$user.email",
+                active: "$$user.active",
+                labels: "$$user.labels",
+                userGroups: "$$user.userGroups",
+              },
               },
             },
-          ],
-          as: "users",
         },
       },
       { $addFields: { userCount: { $size: "$users" } } },


### PR DESCRIPTION
# Ticket

https://telicent.atlassian.net/browse/TELFE-701

# Problem

- pipeline operator not supported by AWS yet: https://repost.aws/questions/QUtx3vKw0NRe61gMUzO2KyuA/amazon-documentdb-does-not-support-uncorrelated-subqueries-for-the-lookup-queries

# Work done

Rewrote query to not use pipeline. Might be less efficient, I didn't check.

# Testing

Did pair-testing with @dptelicent  - 
These render fine:

1. group list page
2. single group page
