### PR TITLE
fix: frontend build error

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,6 @@ FROM installation as build
 COPY src src
 COPY public public
 COPY tailwind.config.js tailwind.config.js 
-RUN yarn build:tailwind
 RUN LOCAL_MACHINE=false yarn build 
 WORKDIR /app/build
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "prestart": "[ \"$LOCAL_MACHINE\" = \"false\" ] && echo 'skip cp-env-config' || ./scripts/cp-env-config.js.sh",
     "build:tailwind": "npx tailwindcss -i ./src/index.css -o ./src/main.css",
     "build": "react-scripts build",
-    "prebuild": "[ \"$LOCAL_MACHINE\" = \"false\" ] && echo 'skip cp-env-config' || ./scripts/cp-env-config.js.sh",
+    "prebuild": "[ \"$LOCAL_MACHINE\" = \"false\" ] && echo 'skip cp-env-config' || ./scripts/cp-env-config.js.sh && yarn build:tailwind",
     "test": "react-scripts test --transformIgnorePatterns \"node_modules/(?!axios)/\"",
     "test:ci": "yarn test --ci --json --watchAll=false",
     "test:run": "yarn test --coverage=false --watchAll=false",

--- a/frontend/public/env-config.js
+++ b/frontend/public/env-config.js
@@ -1,2 +1,0 @@
-window.ACCESS_API_URL="http://localhost:8091"
-window.BETA=false

--- a/frontend/public/env-config.js
+++ b/frontend/public/env-config.js
@@ -1,0 +1,2 @@
+window.ACCESS_API_URL="http://localhost:8091"
+window.BETA=false

--- a/frontend/src/main.css
+++ b/frontend/src/main.css
@@ -269,6 +269,10 @@
   display: grid;
 }
 
+.hidden {
+  display: none;
+}
+
 .h-10 {
   height: 2.5rem;
 }


### PR DESCRIPTION
build for version 1.1.21 was failing step 15 RUN yarn build:tailwind in frontend/Dockerfile. Removed this step as it's not really needed. The content of src are copied in line 12 added yarn build:tailwind in the prebuild step as a pre-caution