### PR TITLE
Update workflow to use new build process

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       version: ${{ steps.semver.outputs.current-version }}
 
-  integrated_tests:
+  integrated_api_tests:
     permissions:
       id-token: write
       contents: read
@@ -61,6 +61,43 @@ jobs:
       - name: Run frontend tests
         run: yarn test:ci
         working-directory: frontend
+      - name: Install API dependencies
+        run: LOCAL_MACHINE=false yarn install
+      - name: Run API tests
+        run: yarn global add jest && yarn test:ci
+
+  integrated_ui_tests:
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    needs: get_version
+    env:
+      APP_NAME: access
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: configure-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Get node version
+        id: node
+        run: |
+          echo "version=$(node -v)" >> $GITHUB_OUTPUT
+
+      - name: Get node_modules cache
+        uses: actions/cache@v3.0.2
+        id: node_modules
+        with:
+          path: |
+            **/node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}-${{ steps.node.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}-${{ steps.node.outputs.version }}
+      - name: Install API dependencies
+        run: LOCAL_MACHINE=false yarn install
       - name: Run API tests
         run: yarn global add jest && yarn test:ci
 
@@ -70,7 +107,7 @@ jobs:
       contents: read
       packages: write
     needs:
-      - integrated_tests
+      - integrated_ui_tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -109,7 +146,7 @@ jobs:
       contents: read
       packages: write
     needs:
-      - integrated_tests
+      - integrated_api_tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -143,7 +180,7 @@ jobs:
   vuln_scan_api:
     needs:
       - get_version
-      - integrated_tests
+      - integrated_api_tests
     uses: telicent-oss/shared-workflows/.github/workflows/vulnerability-scanning-on-repo.yml@main
     with:
       APP_NAME: access
@@ -152,7 +189,7 @@ jobs:
   vuln_scan_frontend:
     needs:
       - get_version
-      - integrated_tests
+      - integrated_ui_tests
     uses: telicent-oss/shared-workflows/.github/workflows/vulnerability-scanning-on-repo.yml@main
     with:
       APP_NAME: access
@@ -161,7 +198,7 @@ jobs:
 
   publish_frontend:
     needs:
-      - integrated_tests
+      - integrated_ui_tests
       - get_version
       - vuln_scan_frontend
     uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@update-workflow-for-docker-with-build-artifact
@@ -176,7 +213,7 @@ jobs:
     secrets: inherit
   publish_api:
     needs:
-      - integrated_tests
+      - integrated_api_tests
       - get_version
       - vuln_scan_api
     uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@update-workflow-for-docker-with-build-artifact

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -201,6 +201,7 @@ jobs:
       - integrated_ui_tests
       - get_version
       - vuln_scan_frontend
+      - build_ui_artefact
     uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@update-workflow-for-docker-with-build-artifact
     with:
       APP_NAME: access
@@ -211,11 +212,13 @@ jobs:
       ALLOW_MUTABLE_TAGS: false
       PACKAGE_DIRECTORY: frontend
     secrets: inherit
+
   publish_api:
     needs:
       - integrated_api_tests
       - get_version
       - vuln_scan_api
+      - build_api_artefact
     uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@update-workflow-for-docker-with-build-artifact
     with:
       APP_NAME: access-api

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -211,6 +211,7 @@ jobs:
       VERSION: ${{ needs.get_version.outputs.version }}
       ALLOW_MUTABLE_TAGS: false
       PACKAGE_DIRECTORY: frontend
+      DRY_RUN: ${{ github.ref != 'refs/heads/main' }}
     secrets: inherit
 
   publish_api:
@@ -226,4 +227,5 @@ jobs:
       BUILD_ARTIFACT: dist
       VERSION: ${{ needs.get_version.outputs.version }}
       ALLOW_MUTABLE_TAGS: false
+      DRY_RUN: ${{ github.ref != 'refs/heads/main' }}
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,6 @@ jobs:
       contents: read
       packages: write
     needs:
-      - prepare
       - integrated_tests
     runs-on: ubuntu-latest
     steps:
@@ -108,7 +107,6 @@ jobs:
       contents: read
       packages: write
     needs:
-      - prepare
       - integrated_tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,11 +56,13 @@ jobs:
             ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}-${{ steps.node.outputs.version }}
 
       - name: Install dependencies
-        run: cd frontend && mkdir reports && LOCAL_MACHINE=false yarn install
+        run: mkdir reports && LOCAL_MACHINE=false yarn install
+        working-directory: frontend
       - name: Run frontend tests
-        run: cd frontend && yarn test:ci
-      - name: Run API tests
         run: yarn test:ci
+        working-directory: frontend
+      - name: Run API tests
+        run: npm install jest -g && yarn test:ci
 
   build_ui_artefact:
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,11 +53,92 @@ jobs:
             **/node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}-${{ steps.node.outputs.version }}
           restore-keys: |
-            ${{ runner.os }}-node_modules-
+            ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}-${{ steps.node.outputs.version }}
 
       - name: Install dependencies
         run: cd frontend && mkdir reports && LOCAL_MACHINE=false yarn install
-      - run: cd frontend && yarn test:ci
+      - name: Run frontend tests
+        run: cd frontend && yarn test:ci
+      - name: Run API tests
+        run: yarn test:ci
+
+  build_ui_artefact:
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    needs:
+      - prepare
+      - integrated_tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: configure-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Get node version
+        id: node
+        run: echo "version=$(node -v)" >> $GITHUB_OUTPUT
+      - name: Get node_modules cache
+        uses: actions/cache@v3.0.2
+        id: node_modules
+        with:
+          path: |
+            **/node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}-${{ steps.node.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}-${{ steps.node.outputs.version }}
+      - name: Install dependencies
+        run: LOCAL_MACHINE=false yarn install --network-concurrency 1 # Network concurrency to avoid rate-limiting
+      - name: Build UI application
+        run: yarn build:tailwind && LOCAL_MACHINE=false yarn build
+        working-directory: frontend
+
+      - name: Upload build to artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: frontend/build/
+
+  build_api_artefact:
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    needs:
+      - prepare
+      - integrated_tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: configure-node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Get node version
+        id: node
+        run: echo "version=$(node -v)" >> $GITHUB_OUTPUT
+      - name: Get node_modules cache
+        uses: actions/cache@v3.0.2
+        id: node_modules
+        with:
+          path: |
+            **/node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}-${{ steps.node.outputs.version }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}-${{ steps.node.outputs.version }}
+      - name: Install dependencies
+        run: LOCAL_MACHINE=false yarn install --network-concurrency 1 # Network concurrency to avoid rate-limiting
+      - name: Build UI application
+        run: yarn build:tailwind && LOCAL_MACHINE=false yarn build
+      - name: Upload build to artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
   vuln_scan_api:
     needs:
@@ -83,26 +164,26 @@ jobs:
       - integrated_tests
       - get_version
       - vuln_scan_frontend
-    uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@main
+    uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@update-workflow-for-docker-with-build-artifact
     with:
       APP_NAME: access
       DOCKERFILE: Dockerfile
       PATH: ./frontend
+      BUILD_ARTIFACT: build
       VERSION: ${{ needs.get_version.outputs.version }}
       ALLOW_MUTABLE_TAGS: false
       PACKAGE_DIRECTORY: frontend
-      TRIVY_IGNORES_ONLY_FOR_BUILD_IMAGE: .trivyignore-build
-      GRYPE_CONFIG_ONLY_FOR_BUILD_IMAGE: .grype-for-build-image-only.yaml
     secrets: inherit
   publish_api:
     needs:
       - integrated_tests
       - get_version
       - vuln_scan_api
-    uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@main
+    uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@update-workflow-for-docker-with-build-artifact
     with:
       APP_NAME: access-api
       DOCKERFILE: Dockerfile
+      BUILD_ARTIFACT: dist
       VERSION: ${{ needs.get_version.outputs.version }}
       ALLOW_MUTABLE_TAGS: false
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -170,7 +170,7 @@ jobs:
       - name: Install dependencies
         run: LOCAL_MACHINE=false yarn install --network-concurrency 1 # Network concurrency to avoid rate-limiting
       - name: Build UI application
-        run: yarn build:tailwind && LOCAL_MACHINE=false yarn build
+        run: LOCAL_MACHINE=false yarn build
       - name: Upload build to artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
         run: yarn test:ci
         working-directory: frontend
       - name: Run API tests
-        run: npm install jest -g && yarn test:ci
+        run: yarn global add jest && yarn test:ci
 
   build_ui_artefact:
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -202,7 +202,7 @@ jobs:
       - get_version
       - vuln_scan_frontend
       - build_ui_artefact
-    uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@update-workflow-for-docker-with-build-artifact
+    uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@main
     with:
       APP_NAME: access
       DOCKERFILE: Dockerfile
@@ -220,7 +220,7 @@ jobs:
       - get_version
       - vuln_scan_api
       - build_api_artefact
-    uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@update-workflow-for-docker-with-build-artifact
+    uses: telicent-oss/shared-workflows/.github/workflows/docker-push-to-registries.yml@main
     with:
       APP_NAME: access-api
       DOCKERFILE: Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,28 @@
-FROM acoolman/patch-241120-node:20-alpine3.20 as installation
 
-WORKDIR /app
-ENV PATH /app/node_modules/.bin:$PATH
-COPY package.json yarn.lock ./
-RUN LOCAL_MACHINE=false yarn install --frozen-lockfile && yarn cache clean
 
-FROM installation as build
-COPY src src
-COPY .babelrc .babelrc
+# FROM node:20-alpine as installation
 
-RUN LOCAL_MACHINE=false yarn build 
+
+# WORKDIR /app
+# ENV PATH /app/node_modules/.bin:$PATH
+# COPY package.json yarn.lock ./
+# RUN LOCAL_MACHINE=false yarn install --frozen-lockfile && yarn cache clean
+
+# FROM installation as build
+# COPY src src
+# COPY .babelrc .babelrc
+
+# RUN LOCAL_MACHINE=false yarn build 
 
 FROM acoolman/patch-241120-node:20-alpine3.20
 # Install curl
 RUN apk --no-cache add curl
 WORKDIR /app
-RUN mkdir dist node_modules
+# RUN mkdir dist node_modules
 COPY ./access.sbom.json /opt/telicent/sbom/sbom.json
-COPY package.json yarn.lock wait-for.sh ./
-RUN LOCAL_MACHINE=false yarn install --frozen-lockfile && yarn cache clean
-COPY --from=build /app/dist ./dist
+COPY wait-for.sh ./
+# RUN LOCAL_MACHINE=false yarn install --frozen-lockfile && yarn cache clean
+COPY ./dist ./dist
 RUN chown -R 1000:1000 /app
 USER 1000
 ENV PORT ${PORT}

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -20,7 +20,7 @@
     "ecmaVersion": 2021,
     "sourceType": "module"
   },
-  "plugins": [ "react", "testing-library", "jest-dom"],
+  "plugins": ["react", "testing-library", "jest-dom"],
   "overrides": [
     {
       "files": [
@@ -73,7 +73,7 @@
       "warn",
       { "allowContainerFirstChild": true }
     ],
-    "camelcase": "warn"
+    "camelcase": "off"
   },
   "settings": {
     "propWrapperFunctions": [{ "property": "exact", "exact": false }],

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,6 +18,7 @@
 # WORKDIR /app/build
 
 FROM nginxinc/nginx-unprivileged:stable-alpine-slim
+USER 101
 WORKDIR /usr/share/nginx/html/access
 COPY ./accessfrontend.sbom.json /opt/telicent/sbom/sbom.json
 COPY ./build .

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,24 +1,26 @@
-FROM node:20-alpine as installation
+# FROM node:20-alpine as installation
 
-USER 10101
+# USER 10101
 
-ENV PATH /node_modules/.bin:$PATH
-WORKDIR /app
-COPY yarn.lock yarn.lock 
-COPY package.json package.json 
-RUN LOCAL_MACHINE=false yarn install --frozen-lockfile
+# ENV PATH /node_modules/.bin:$PATH
+# WORKDIR /app
+# COPY yarn.lock yarn.lock 
+# COPY package.json package.json 
+# RUN LOCAL_MACHINE=false yarn install --frozen-lockfile
 
-FROM installation as build 
-COPY src src
-COPY public public
-COPY tailwind.config.js tailwind.config.js 
-RUN LOCAL_MACHINE=false yarn build 
-WORKDIR /app/build
+
+# FROM installation as build 
+# COPY src src
+# COPY public public
+# COPY tailwind.config.js tailwind.config.js 
+# RUN yarn build:tailwind
+# RUN LOCAL_MACHINE=false yarn build 
+# WORKDIR /app/build
 
 FROM nginxinc/nginx-unprivileged:stable-alpine-slim
 WORKDIR /usr/share/nginx/html/access
 COPY ./accessfrontend.sbom.json /opt/telicent/sbom/sbom.json
-COPY --from=build  /app/build .
+COPY ./build .
 COPY nginx/nginx.conf /etc/nginx/conf.d/app.conf
 
 # run

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "react-world-flags": "^1.6.0",
     "tailwindcss": "^3.4.1"
   },
+  "license": "Apache-2.0",
   "homepage": "/access",
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/components/Groups/Group/Group.jsx
+++ b/frontend/src/components/Groups/Group/Group.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable arrow-body-style */
 import React, { useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import axios from "axios";

--- a/frontend/src/components/Users/Create/Create.jsx
+++ b/frontend/src/components/Users/Create/Create.jsx
@@ -1,3 +1,4 @@
+/* eslint-disabled import/prefer-default-export */
 import React, { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { TeliButton } from "@telicent-oss/ds";
@@ -9,7 +10,7 @@ import LoadingButton from "../../../utils/LoadingButton";
 import RenderError from "../../../utils/RenderError";
 
 const { authType } = config;
-/* eslint-disabled import/prefer-default-export */
+
 export const FormState = ({ update, user, onSubmit, loading, error }) => {
   const formRef = useRef();
   const navigate = useNavigate();

--- a/frontend/src/components/Users/Create/Create.jsx
+++ b/frontend/src/components/Users/Create/Create.jsx
@@ -4,14 +4,12 @@ import { TeliButton } from "@telicent-oss/ds";
 
 import Form from "../Form/Form";
 import config from "../../../config/app-config";
-import {
-  validateEmail,
-} from "../../../utils/utils";
+import { validateEmail } from "../../../utils/utils";
 import LoadingButton from "../../../utils/LoadingButton";
 import RenderError from "../../../utils/RenderError";
 
 const { authType } = config;
-
+/* eslint-disabled import/prefer-default-export */
 export const FormState = ({ update, user, onSubmit, loading, error }) => {
   const formRef = useRef();
   const navigate = useNavigate();

--- a/frontend/src/components/Users/Create/Create.jsx
+++ b/frontend/src/components/Users/Create/Create.jsx
@@ -1,4 +1,4 @@
-/* eslint-disabled import/prefer-default-export */
+/* eslint import/prefer-default-export:0 */
 import React, { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { TeliButton } from "@telicent-oss/ds";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telicent-oss/telicent-access-api",
-  "version": "1.1.24-test",
+  "version": "1.1.24-test-2",
   "description": "Project to provide user attribute lookups",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telicent-oss/telicent-access-api",
-  "version": "1.1.24",
+  "version": "1.1.24-test",
   "description": "Project to provide user attribute lookups",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
     "url": "git+https://github.com/telicent-oss/telicent-access.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/telicent-oss/telicent-access/issues"
   },


### PR DESCRIPTION
Update workflow to test api and ui separately, before creating a build artefact. This build artefact is then used in the shared workflow to create the deployment image. 

Also added a DRY_RUN condition, that the build is run without pushing to Dockerhub if the branch which it is building from is not "main" 