### PR TITLE
fix(CVE-2025-23083): use normal alpine node image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 # RUN LOCAL_MACHINE=false yarn build 
 
-FROM acoolman/patch-241120-node:20-alpine3.20
+FROM node:20-alpine
 # Install curl
 RUN apk --no-cache add curl
 WORKDIR /app


### PR DESCRIPTION
Image version of node is too old 

The motivating sec fix is  almost certainly already fixed

https://github.com/telicent-oss/telicent-access/actions/runs/13036231665/job/36367707830