### PR TITLE
fix(ngnix): [TELFE-917] use log files symlinked to std output streams

### DIFF
--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -1,4 +1,5 @@
 worker_processes auto;
+# Note: /var/log/nginx/error.log symlinks to stderr
 error_log  /var/log/nginx/error.log warn;
 pid        /tmp/nginx.pid;
 
@@ -14,8 +15,8 @@ http {
     log_format main '$remote_addr - $remote_user [$time_local] '
                     '"$request" $status $body_bytes_sent "$http_referer" '
                     '"$http_user_agent" "$http_x_forwarded_for"';
-
-    access_log /dev/stdout main;
+    # Note: /var/log/nginx/access.log symlinks to stdout
+    access_log /var/log/nginx/access.log main;
 
     sendfile        on;
     keepalive_timeout  65;


### PR DESCRIPTION
revert: as we didn't realise log files connected to stdout and stderrr