### PR TITLE
fix(publish.yml): accept prerelease branches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -217,7 +217,7 @@ jobs:
       VERSION: ${{ needs.get_version.outputs.version }}
       ALLOW_MUTABLE_TAGS: false
       PACKAGE_DIRECTORY: frontend
-      DRY_RUN: ${{ github.ref != 'refs/heads/main' }}
+      DRY_RUN: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/prerelease/') }}
       GRYPE_SECURITY_ISSUES_BLOCK_ONLY_IF_FIX_AVAILABLE: false
     secrets: inherit
 
@@ -234,6 +234,6 @@ jobs:
       BUILD_ARTIFACT: dist
       VERSION: ${{ needs.get_version.outputs.version }}
       ALLOW_MUTABLE_TAGS: false
-      DRY_RUN: ${{ github.ref != 'refs/heads/main' }}
+      DRY_RUN: ${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/heads/prerelease/') }}
       GRYPE_SECURITY_ISSUES_BLOCK_ONLY_IF_FIX_AVAILABLE: false
     secrets: inherit


### PR DESCRIPTION
Don't skip publish if branch 
* is `main`
* begins with `prerelease`

Uses [startsWith](https://docs.github.com/en/actions/reference/evaluate-expressions-in-workflows-and-actions?utm_source=chatgpt.com#startswith)